### PR TITLE
Add support for Postgres 16

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,9 +5,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build-ruby3-pg14:
+  build-ruby3.0-pg14:
     runs-on: ubuntu-latest
-
     steps:
     - name: Checkout
       uses: actions/checkout@v2
@@ -30,6 +29,21 @@ jobs:
         tags: easyredir/ruby-psql:3.0-14
         cache-from: type=registry,ref=user/app:latest
         cache-to: type=inline
+
+  build-ruby3.1-pg14:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build and push Ruby 3.1 with PostgreSQL 14 client
       uses: docker/build-push-action@v2
       with:
@@ -40,6 +54,21 @@ jobs:
         tags: easyredir/ruby-psql:3.1-14
         cache-from: type=registry,ref=user/app:latest
         cache-to: type=inline
+
+  build-ruby3.1-pg16:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v1
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build and push Ruby 3.1 with PostgreSQL 16 client
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -5,7 +5,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  build-ruby3-pg14:
     runs-on: ubuntu-latest
 
     steps:
@@ -20,26 +20,6 @@ jobs:
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build and push Ruby 2.6 with PostgreSQL 14 client
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./2.6-14/Dockerfile
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: easyredir/ruby-psql:2.6-14
-        cache-from: type=registry,ref=user/app:latest
-        cache-to: type=inline
-    - name: Build and push Ruby 2.7 with PostgreSQL 14 client
-      uses: docker/build-push-action@v2
-      with:
-        context: .
-        file: ./2.7-14/Dockerfile
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: easyredir/ruby-psql:2.7-14
-        cache-from: type=registry,ref=user/app:latest
-        cache-to: type=inline
     - name: Build and push Ruby 3.0 with PostgreSQL 14 client
       uses: docker/build-push-action@v2
       with:
@@ -58,5 +38,15 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: easyredir/ruby-psql:3.1-14
+        cache-from: type=registry,ref=user/app:latest
+        cache-to: type=inline
+    - name: Build and push Ruby 3.1 with PostgreSQL 16 client
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./3.1-16/Dockerfile
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: easyredir/ruby-psql:3.1-16
         cache-from: type=registry,ref=user/app:latest
         cache-to: type=inline

--- a/3.1-16/Dockerfile
+++ b/3.1-16/Dockerfile
@@ -1,0 +1,14 @@
+FROM easyredir/ruby:3.1
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV PG_MAJOR 16
+
+RUN curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /usr/share/keyrings/postgresql.gpg
+RUN sh -c 'echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/postgresql.list'
+
+RUN apt-get update \
+	&& apt-get install -y postgresql-client-$PG_MAJOR \
+	&& rm -rf /root/* \
+	&& rm -rf /tmp/* \
+	&& rm -rf /var/cache/apt/archives/*.deb \
+	&& rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
(Creating PR from a fork since I don't have necessary permissions to push branches/PRs on the base repo)

Some EasyRedir applications run the `3.1-14` image in which `pg_dump` and other client binaries are compatible with Postgres server 14. Now that applications are bumped to connect with databases running Postgres 16, the client-side libraries should be updated too.

For example, seeing compatibility issues when attempting to generate `structure.sql` on containers running `3.1-14` connected to postgres 16 database containers.

On Rails app server startup, or `rails db:setup`, etc.

```
pg_dump: error: server version: 16.1; pg_dump version: 14.8 (Ubuntu 14.8-1.pgdg22.04+1)
pg_dump: error: aborting because of server version mismatch
rake aborted!
failed to execute:
pg_dump --schema-only --no-privileges --no-owner --file /app/db/structure.sql er-management_dev

Please check the output above for any errors and make sure that `pg_dump` is installed in your PATH and has proper permissions.


```