### PR TITLE
Replace use of lsb-release

### DIFF
--- a/3.1-16/Dockerfile
+++ b/3.1-16/Dockerfile
@@ -4,7 +4,8 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV PG_MAJOR 16
 
 RUN curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /usr/share/keyrings/postgresql.gpg
-RUN sh -c 'echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/postgresql.list'
+
+RUN sh -c 'echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt $(cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2)-pgdg main" > /etc/apt/sources.list.d/postgresql.list'
 
 RUN apt-get update \
 	&& apt-get install -y postgresql-client-$PG_MAJOR \


### PR DESCRIPTION
`lsb-release` is no longer a base package in upcoming Ubuntu versions and was removed from current base images too. This posed a problem when attempting to rebuild this repo's image from scratch.

This commit runs an alternative to `lsb-release` to obtain the ubuntu version name, to fetch the appropriate postgres deb package.